### PR TITLE
Accept several options via bin to specify wordle number

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ DESCRIPTION
 
 Games::Wordle is a Raku implementation of the game Wordle, hosted by The New York Times at [https://www.nytimes.com/games/wordle/index.html](https://www.nytimes.com/games/wordle/index.html)
 
-Games::Wordle uses the same word list and daily answers as the NYT version by default. You may also customize the game by providing your own answer, list of valid inputs, or number of guesses via the `new` method with the options `:answer`, `:valid-inputs`, and `:guess-limit`. The tiles can also be changed with the `:correct-tile`, `:present-tile`, and `absent-tile` options.
+Games::Wordle uses the same word list and daily answers as the NYT version by default. You may also customize the game by providing your own answer, list of valid inputs, or number of guesses via the `new` method with the options `:answer`, `:valid-inputs`, and `:guess-limit`. The tiles can also be changed with the `:correct-tile`, `:present-tile`, and `:absent-tile` options.
 
 The class is intended to be flexible, allowing for constructing Wordle variants with options via the `new` method.
 

--- a/bin/wordle.raku
+++ b/bin/wordle.raku
@@ -2,27 +2,31 @@
 
 use Games::Wordle;
 
-subset Number of Str where !.defined || (.Int.so && .Int > 0);
+multi MAIN (Int:D $number) { samewith(:$number) }
 
-unit sub MAIN (Number :$number);
+multi MAIN (
+	IntStr :n(:$number), #= Specify which daily Wordle to attempt.
+) {
+	my Games::Wordle $wordle.=new(
+		|(:$number if $number.defined && $number.chars),
+	);
 
-my Games::Wordle $wordle.=new: |do :number(.Int) with $number;
+	"Wordle $wordle.number()\nEnter your guess:".say;
 
-"Wordle $wordle.number()\nEnter your guess:".say;
-
-until $wordle.result {
-	with prompt '> ' -> $in {
-		 with $wordle.guess($in) {
-			.join.say
+	until $wordle.result {
+		with prompt '> ' -> $in {
+			 with $wordle.guess($in) {
+				.join.say
+			}
+			else {
+				.exception.message.say
+			}
 		}
 		else {
-			.exception.message.say
+			''.say;
+			exit;
 		}
 	}
-	else {
-		''.say;
-		exit;
-	}
-}
 
-"\n$wordle.answer()\n\n$wordle.result()".say;
+	"\n$wordle.answer()\n\n$wordle.result()".say;
+}

--- a/lib/Games/Wordle.rakumod
+++ b/lib/Games/Wordle.rakumod
@@ -5,7 +5,7 @@ my class X::Games::Wordle::InvalidGuess does X::Games::Wordle {
 	has Str $.reason;
 
 	method message {
-		"｢$.guess｣ is not a valid guess.{ ' ' if $.reason }$.reason"
+		“｢$.guess｣ is not a valid guess.{ “ $_” with $.reason }”
 	}
 }
 
@@ -34,7 +34,12 @@ class Games::Wordle:ver<0.0.3> {
 			$!number = Nil;
 		}
 		orwith %?RESOURCES<answers.txt> {
-			$!answer = .lines[$!number % *];
+			given .lines -> @lines {
+				given +@lines {
+					$!number = $!number % $_ || $_;
+				}
+				$!answer = @lines[$!number - 1];
+			}
 		}
 		else {
 			$!answer = 'CAMEL';
@@ -167,7 +172,7 @@ Games::Wordle is a Raku implementation of the game Wordle, hosted by The New Yor
 Games::Wordle uses the same word list and daily answers as the NYT version by default.
 You may also customize the game by providing your own answer, list of valid inputs, or number of guesses
 via the C<new> method with the options C<:answer>, C<:valid-inputs>, and C<:guess-limit>.
-The tiles can also be changed with the C<:correct-tile>, C<:present-tile>, and C<absent-tile> options.
+The tiles can also be changed with the C<:correct-tile>, C<:present-tile>, and C<:absent-tile> options.
 
 The class is intended to be flexible, allowing for constructing Wordle variants with options via the `new` method.
 

--- a/lib/Games/Wordle.rakumod
+++ b/lib/Games/Wordle.rakumod
@@ -34,11 +34,9 @@ class Games::Wordle:ver<0.0.3> {
 			$!number = Nil;
 		}
 		orwith %?RESOURCES<answers.txt> {
-			given .lines -> @lines {
-				given +@lines {
-					$!number = $!number % $_ || $_;
-				}
-				$!answer = @lines[$!number - 1];
+			given .lines {
+				$!number = $!number % +$_;
+				$!answer = .[$!number];
 			}
 		}
 		else {

--- a/lib/Games/Wordle.rakumod
+++ b/lib/Games/Wordle.rakumod
@@ -34,10 +34,7 @@ class Games::Wordle:ver<0.0.3> {
 			$!number = Nil;
 		}
 		orwith %?RESOURCES<answers.txt> {
-			given .lines {
-				$!number = $!number % +$_;
-				$!answer = .[$!number];
-			}
+			$!answer = .lines[$!number %= *];
 		}
 		else {
 			$!answer = 'CAMEL';


### PR DESCRIPTION
Allows for a number to be specified as a single arg, or with the options `-n` or `--number`.